### PR TITLE
fix(pdfamex): accept uppercase masked account numbers

### DIFF
--- a/pdfamex/pdfamex.py
+++ b/pdfamex/pdfamex.py
@@ -34,8 +34,10 @@ class PDFAmex(beangulp.Importer):
         BALANCE_PATTERN (str): Motif regex pour extraire le solde total.
     """
 
-    ACCOUNT_NUMBER_PATTERN = r"xxxx-xxxxxx-(\d{5})"
-    STATEMENT_DATE_PATTERN = r"xxxx-xxxxxx-\d{5}\s*(\d*/\d*/\d*)"
+    ACCOUNT_NUMBER_PATTERN = r"[xX]{4}\s*-\s*[xX]{6}\s*-\s*(\d{5})"
+    STATEMENT_DATE_PATTERN = (
+        r"[xX]{4}\s*-\s*[xX]{6}\s*-\s*\d{5}\s*(\d{1,2}/\d{1,2}/\d{2,4})"
+    )
     TRANSACTION_PATTERN = r"\d{1,2}\s[a-zéèûôùê]{3,4}\s*\d{1,2}\s[a-zéèûôùê]{3,4}.*\d+,\d{2}(?:\s*CR)?"
     TRANSACTION_DATE_PATTERN = (
         r"(\d{1,2}\s[a-zéèûôùê]{3,4})\s*(\d{1,2}\s[a-zéèûôùê]{3,4})"

--- a/pdfamex/pdfamex_test.py
+++ b/pdfamex/pdfamex_test.py
@@ -20,6 +20,18 @@ IMPORTER = pdfamex.PDFAmex(ACCOUNTLIST)
 
 TESTDIR = path.abspath("regtest/Beancount-myTools-tests/pdfamex/")
 
+AMEX_UPPERCASE_ACCOUNT_TEXT = """
+Carte Air France KLM - American Express Gold
+Numéro de Compte
+XXXX-XXXXXX-72001
+"""
+
+AMEX_UPPERCASE_ACCOUNT_WITH_DATE_TEXT = """
+XXXX-XXXXXX-72001
+08/05/26
+"""
+
+
 def get_test_files():
     if not path.isdir(TESTDIR):
         return []
@@ -31,11 +43,28 @@ def get_test_files():
                 files.append(path.join(TESTDIR, f))
     return files
 
+
 @pytest.mark.parametrize("doc", get_test_files())
 def test_importer(doc):
     assert IMPORTER.identify(doc)
     account, date, name, entries = run_importer(IMPORTER, doc)
     expected_filename = doc + ".beancount"
-    
+
     diff = compare_expected(expected_filename, account, date, name, entries)
     assert not diff, "Diff found:\n" + "".join(diff)
+
+
+def test_account_and_date_accept_uppercase_masked_number(monkeypatch):
+    importer = pdfamex.PDFAmex(ACCOUNTLIST)
+    monkeypatch.setattr(importer, "_get_pdf_text", lambda _: AMEX_UPPERCASE_ACCOUNT_TEXT)
+
+    assert importer.account("dummy.pdf") == "Passif:AirFrance:Amex"
+
+    monkeypatch.setattr(
+        importer,
+        "_get_pdf_text",
+        lambda _: AMEX_UPPERCASE_ACCOUNT_WITH_DATE_TEXT,
+    )
+    parsed_date = importer.date("dummy.pdf")
+    assert parsed_date is not None
+    assert parsed_date.isoformat() == "2026-05-08"


### PR DESCRIPTION
## Summary
- make `pdfamex` accept uppercase masked account numbers from PDF extraction
- tolerate whitespace around masked-number separators when parsing account/date headers
- add an anonymized regression test for account and statement-date extraction

## Context
An Amex statement review failed because the extracted header contained `XXXX-XXXXXX-72001` instead of the lowercase form the importer expected.

## Test Plan
- [x] `./.venv/bin/pytest myTools/pdfamex/pdfamex_test.py -v`
- [x] replayed the real Beancount workflow review on the affected statement locally
