### PR TITLE
fix(pdfbanquepopulaire): handle OCR-corrupted SCI statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Important :
 - aucun releve reel ne doit etre ajoute dans `myTools` ;
 - les tests de cet importeur doivent rester bases sur du texte synthetique et
   anonymise, car le depot GitHub est public.
+- l'importeur tolere des extractions OCR degradees sur certains releves SCI
+  Banque Populaire (montants sans separateur decimal, detail SEPA utilise comme
+  source de verite, solde de cloture derive si la ligne de solde est tronquee).
 
 ## PDFAmex
 

--- a/pdfbanquepopulaire/pdfbanquepopulaire.py
+++ b/pdfbanquepopulaire/pdfbanquepopulaire.py
@@ -52,7 +52,7 @@ class PDFBanquePopulaire(beangulp.Importer):
         r"(?P<reference>[A-Z0-9]{7,})\s+"
         r"(?P<operation>\d{2}/\d{2})\s+"
         r"(?P<value>\d{2}/\d{2})\s+"
-        r"(?P<amount>[+-]?\s*\d(?:[\d .]*\d)?,\d{2})\s*€\s*$"
+        r"(?P<amount>[+-]?\s*\d(?:[\d .]*\d)?(?:[.,]\d{2})?)\s*€\s*$"
     )
 
     def __init__(self, account_list: dict[str, str], debug: bool = False):
@@ -114,6 +114,7 @@ class PDFBanquePopulaire(beangulp.Importer):
         entries: List[data.Directive] = []
 
         opening_balance, closing_balance = self._extract_balances(text)
+        sepa_detail_amounts = self._extract_sepa_detail_amounts(text)
         if opening_balance:
             status, raw_date, raw_amount = opening_balance
             balance_date = (
@@ -131,8 +132,9 @@ class PDFBanquePopulaire(beangulp.Importer):
                 )
             )
 
+        transaction_entries: list[data.Transaction] = []
         for index, block in enumerate(self._split_transaction_blocks(text), start=1):
-            entries.append(
+            transaction_entries.append(
                 self._parse_transaction_block(
                     block_lines=block,
                     statement_date=statement_date,
@@ -140,8 +142,10 @@ class PDFBanquePopulaire(beangulp.Importer):
                     file=str(file),
                     line=index,
                     document=document,
+                    sepa_detail_amounts=sepa_detail_amounts,
                 )
             )
+        entries.extend(transaction_entries)
 
         if closing_balance:
             status, raw_date, raw_amount = closing_balance
@@ -153,6 +157,21 @@ class PDFBanquePopulaire(beangulp.Importer):
                     entry_date=balance_date,
                     account_name=account_name,
                     balance_amount=self._balance_amount(status, raw_amount),
+                    document=document,
+                )
+            )
+        elif opening_balance and transaction_entries:
+            status, _raw_date, raw_amount = opening_balance
+            derived_closing_amount = self._balance_amount(status, raw_amount)
+            for entry in transaction_entries:
+                derived_closing_amount += entry.postings[0].units.number
+            entries.append(
+                self._create_balance(
+                    file=str(file),
+                    line=0,
+                    entry_date=statement_date,
+                    account_name=account_name,
+                    balance_amount=derived_closing_amount,
                     document=document,
                 )
             )
@@ -175,9 +194,21 @@ class PDFBanquePopulaire(beangulp.Importer):
         if not matches:
             return None, None
 
-        opening = matches[0]
-        closing = matches[-1]
-        return opening.groups(), closing.groups()
+        opening_match = matches[0]
+        opening = (
+            opening_match.group(1),
+            opening_match.group(2),
+            opening_match.group(3),
+        )
+        if len(matches) == 1:
+            return opening, None
+        closing_match = matches[-1]
+        closing = (
+            closing_match.group(1),
+            closing_match.group(2),
+            closing_match.group(3),
+        )
+        return opening, closing
 
     def _split_transaction_blocks(self, text: str) -> list[list[str]]:
         section = self._extract_main_operations_section(text)
@@ -242,6 +273,7 @@ class PDFBanquePopulaire(beangulp.Importer):
         file: str,
         line: int,
         document: str,
+        sepa_detail_amounts: dict[str, Decimal],
     ) -> data.Transaction:
         first_line_match = re.match(
             r"^\s*(\d{2}/\d{2})(?:\s+[A-Z]\s+)?(.*)$", block_lines[0]
@@ -303,7 +335,12 @@ class PDFBanquePopulaire(beangulp.Importer):
         transaction_date = self._resolve_partial_date(
             detail_match.group("value"), statement_date
         )
-        transaction_amount = self._parse_decimal(detail_match.group("amount"))
+        transaction_amount = self._resolve_transaction_amount(
+            raw_amount=detail_match.group("amount"),
+            payee=payee,
+            block_lines=block_lines,
+            sepa_detail_amounts=sepa_detail_amounts,
+        )
 
         meta = data.new_metadata(file, line)
         meta["source"] = "pdfbanquepopulaire"
@@ -366,15 +403,28 @@ class PDFBanquePopulaire(beangulp.Importer):
         return abs(value)
 
     def _parse_decimal(self, raw_amount: str) -> Decimal:
-        cleaned = (
-            raw_amount.replace("€", "")
-            .replace("\xa0", " ")
-            .replace(".", "")
-            .strip()
-        )
+        cleaned = raw_amount.replace("€", "").replace("\xa0", " ").strip()
         sign = -1 if "-" in cleaned else 1
-        cleaned = cleaned.replace("-", "").replace("+", "").replace(" ", "")
-        cleaned = cleaned.replace(",", ".")
+        cleaned = cleaned.replace("-", "").replace("+", "").strip()
+
+        if "," not in cleaned and "." not in cleaned:
+            digits = cleaned.replace(" ", "")
+            if digits.isdigit():
+                cleaned = (
+                    f"{digits[:-2]}.{digits[-2:]}"
+                    if len(digits) > 2
+                    else f"0.{digits.zfill(2)}"
+                )
+            else:
+                cleaned = digits
+        else:
+            compact = cleaned.replace(" ", "")
+            if "," in compact:
+                compact = compact.replace(".", "").replace(",", ".")
+            elif "." in compact:
+                integer_part, decimal_part = compact.rsplit(".", 1)
+                compact = integer_part.replace(".", "") + "." + decimal_part
+            cleaned = compact
         try:
             value = Decimal(cleaned)
         except InvalidOperation as exc:
@@ -382,6 +432,52 @@ class PDFBanquePopulaire(beangulp.Importer):
                 f"Montant Banque Populaire invalide: {raw_amount!r}"
             ) from exc
         return value * sign
+
+    def _resolve_transaction_amount(
+        self,
+        *,
+        raw_amount: str,
+        payee: str,
+        block_lines: list[str],
+        sepa_detail_amounts: dict[str, Decimal],
+    ) -> Decimal:
+        if payee.upper().startswith("PRLV SEPA"):
+            joined_block = " ".join(
+                self._normalize_spaces(line) for line in block_lines if line.strip()
+            )
+            for reference, amount_value in sepa_detail_amounts.items():
+                if reference in joined_block:
+                    return amount_value
+        return self._parse_decimal(raw_amount)
+
+    def _extract_sepa_detail_amounts(self, text: str) -> dict[str, Decimal]:
+        marker = "DETAIL DE VOS MOUVEMENTS SEPA"
+        upper = text.upper()
+        section_index = upper.find(marker)
+        if section_index == -1:
+            return {}
+
+        lines = [
+            self._normalize_spaces(line)
+            for line in text[section_index:].splitlines()
+            if self._normalize_spaces(line)
+        ]
+        results: dict[str, Decimal] = {}
+        amount_pattern = re.compile(r"(?<![A-Z0-9])\d(?:[\d ]*\d)?[,.]\d{2}")
+        reference_pattern = re.compile(r"^(?P<reference>[A-Z0-9]{12,})\b")
+
+        for index, line in enumerate(lines[:-1]):
+            amount_matches = amount_pattern.findall(line)
+            if not amount_matches:
+                continue
+            reference_match = reference_pattern.match(lines[index + 1])
+            if not reference_match:
+                continue
+            results[reference_match.group("reference")] = -abs(
+                self._parse_decimal(amount_matches[-1])
+            )
+
+        return results
 
     def _create_balance(
         self,

--- a/pdfbanquepopulaire/pdfbanquepopulaire.py
+++ b/pdfbanquepopulaire/pdfbanquepopulaire.py
@@ -113,7 +113,9 @@ class PDFBanquePopulaire(beangulp.Importer):
         document = f"{statement_date} {self.filename(file)}"
         entries: List[data.Directive] = []
 
-        opening_balance, closing_balance = self._extract_balances(text)
+        opening_balance, closing_balance = self._extract_balances(
+            text, statement_date
+        )
         sepa_detail_amounts = self._extract_sepa_detail_amounts(text)
         if opening_balance:
             status, raw_date, raw_amount = opening_balance
@@ -185,7 +187,7 @@ class PDFBanquePopulaire(beangulp.Importer):
         return match.group(1)
 
     def _extract_balances(
-        self, text: str
+        self, text: str, statement_date: dt.date
     ) -> tuple[
         Optional[tuple[str, str, str]],
         Optional[tuple[str, str, str]],
@@ -201,6 +203,11 @@ class PDFBanquePopulaire(beangulp.Importer):
             opening_match.group(3),
         )
         if len(matches) == 1:
+            single_balance_date = parse_datetime(
+                opening_match.group(2), dayfirst=True
+            ).date()
+            if single_balance_date == statement_date:
+                return None, opening
             return opening, None
         closing_match = matches[-1]
         closing = (

--- a/pdfbanquepopulaire/pdfbanquepopulaire.py
+++ b/pdfbanquepopulaire/pdfbanquepopulaire.py
@@ -162,7 +162,7 @@ class PDFBanquePopulaire(beangulp.Importer):
                     document=document,
                 )
             )
-        elif opening_balance and transaction_entries:
+        elif opening_balance:
             status, _raw_date, raw_amount = opening_balance
             derived_closing_amount = self._balance_amount(status, raw_amount)
             for entry in transaction_entries:

--- a/pdfbanquepopulaire/pdfbanquepopulaire_test.py
+++ b/pdfbanquepopulaire/pdfbanquepopulaire_test.py
@@ -7,8 +7,8 @@ from . import pdfbanquepopulaire
 
 
 ACCOUNTLIST = {
-    "12345678901": "Actif:BanquePopulaire:CCAnna",
-    "36319151452": "Actif:BPop:CCTim",
+    "12345678901": "Actif:BanquePopulaire:CCPrincipal",
+    "36319151452": "Actif:BPop:CCSecondaire",
 }
 
 SYNTHETIC_STATEMENT = """BANQUE POPULAIRE
@@ -42,7 +42,7 @@ def test_identify_date_and_account(monkeypatch):
 
     assert importer.identify("statement.pdf")
     assert importer.filename("statement.pdf") == "Relevé Compte.pdf"
-    assert importer.account("statement.pdf") == "Actif:BanquePopulaire:CCAnna"
+    assert importer.account("statement.pdf") == "Actif:BanquePopulaire:CCPrincipal"
     assert importer.date("statement.pdf") == dt.date(2026, 3, 31)
 
 
@@ -120,7 +120,7 @@ def test_extract_bpop_cctim_statement(monkeypatch):
     )
     importer = pdfbanquepopulaire.PDFBanquePopulaire(ACCOUNTLIST)
 
-    assert importer.account("statement.pdf") == "Actif:BPop:CCTim"
+    assert importer.account("statement.pdf") == "Actif:BPop:CCSecondaire"
 
     entries = importer.extract("statement.pdf")
     balances = [entry for entry in entries if isinstance(entry, data.Balance)]
@@ -143,7 +143,7 @@ def test_extract_bpop_cctim_statement(monkeypatch):
         == "XCGFC005 2026032700059725000001 CONTRAT CARTE ********788J"
     )
     assert [posting.account for posting in transactions[0].postings] == [
-        "Actif:BPop:CCTim",
+        "Actif:BPop:CCSecondaire",
         "Depenses:Banque:Frais",
     ]
     assert transactions[0].postings[0].units.number == Decimal("-136.30")
@@ -152,15 +152,15 @@ def test_extract_bpop_cctim_statement(monkeypatch):
 
 SYNTHETIC_BP_CCSCI_STATEMENT = """BANQUE POPULAIRE
 Votre relevé de compte n°3 au 31/03/2026
-DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 76321119905
+DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 22334455667
 
 SOLDE CREDITEUR AU 27/02/2026                                                                                 31 000,00 €
-02/03             PRLV SEPA In Extenso Cen                                                                 05G1U1S              02/03                 02/03                         - 1 380,00 €
-                    MFA0577356
-                    643393-B13-001
-18/03             EVI ME MARTIAL FAUCHER C                                                                 SK3RTPF              18/03                 18/03                            480,00 €
-                    MF PAYE SCI LES RAGONDINS 79 DIS
-                    PO S/PROV FRAIS VTE SCI AUGUSTA
+02/03             PRLV SEPA FOURNISSEUR TEST                                                            05G1U1S              02/03                 02/03                         - 1 380,00 €
+                    DOSSIER TEST 001
+                    REFERENCE TEST B13-001
+18/03             EVI ME PRESTATAIRE TEST                                                             SK3RTPF              18/03                 18/03                            480,00 €
+                    REGLEMENT DOSSIER TEST 01
+                    POUR FACTURE TEST AUGUSTA
 
 TOTAL DES MOUVEMENTS DEBITEURS                                                                             - 1 380,00 €
 TOTAL DES MOUVEMENTS CREDITEURS                                                                                480,00 €
@@ -176,25 +176,25 @@ def test_identify_current_account_statement(monkeypatch):
         lambda _: SYNTHETIC_BP_CCSCI_STATEMENT,
     )
     importer = pdfbanquepopulaire.PDFBanquePopulaire(
-        {**ACCOUNTLIST, "76321119905": "Actif:SCIRagondins:CCSCI"}
+        {**ACCOUNTLIST, "22334455667": "Actif:Tests:CCSCI"}
     )
 
     assert importer.identify("statement.pdf")
-    assert importer.account("statement.pdf") == "Actif:SCIRagondins:CCSCI"
+    assert importer.account("statement.pdf") == "Actif:Tests:CCSCI"
     assert importer.date("statement.pdf") == dt.date(2026, 3, 31)
 
 
 SYNTHETIC_BP_CCSCI_WITH_SEPA_SECTION = """BANQUE POPULAIRE
 Votre relevé de compte n°3 au 31/03/2026
-DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 76321119905
+DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 22334455667
 
 SOLDE CREDITEUR AU 27/02/2026                                                                                 31 000,00 €
-02/03             PRLV SEPA In Extenso Cen                                                                 05G1U1S              02/03                 02/03                         - 1 380,00 €
-                    MFA0577356
-                    643393-B13-001
-18/03             EVI ME MARTIAL FAUCHER C                                                                 SK3RTPF              18/03                 18/03                            480,00 €
-                    MF PAYE SCI LES RAGONDINS 79 DIS
-                    PO S/PROV FRAIS VTE SCI AUGUSTA
+02/03             PRLV SEPA FOURNISSEUR TEST                                                            05G1U1S              02/03                 02/03                         - 1 380,00 €
+                    DOSSIER TEST 001
+                    REFERENCE TEST B13-001
+18/03             EVI ME PRESTATAIRE TEST                                                             SK3RTPF              18/03                 18/03                            480,00 €
+                    REGLEMENT DOSSIER TEST 01
+                    POUR FACTURE TEST AUGUSTA
 
 SOLDE CREDITEUR AU 31/03/2026*
 (*) Sous réserve des opérations en cours d'enregistrement.
@@ -210,7 +210,7 @@ def test_extract_current_account_without_totals_block(monkeypatch):
         lambda _: SYNTHETIC_BP_CCSCI_WITH_SEPA_SECTION,
     )
     importer = pdfbanquepopulaire.PDFBanquePopulaire(
-        {**ACCOUNTLIST, "76321119905": "Actif:SCIRagondins:CCSCI"}
+        {**ACCOUNTLIST, "22334455667": "Actif:Tests:CCSCI"}
     )
 
     entries = importer.extract("statement.pdf")
@@ -219,18 +219,18 @@ def test_extract_current_account_without_totals_block(monkeypatch):
     ]
 
     assert len(transactions) == 2
-    assert transactions[0].payee == "PRLV SEPA In Extenso Cen"
-    assert transactions[1].payee == "EVI ME MARTIAL FAUCHER C"
+    assert transactions[0].payee == "PRLV SEPA FOURNISSEUR TEST"
+    assert transactions[1].payee == "EVI ME PRESTATAIRE TEST"
 
 
 SYNTHETIC_BP_CCSCI_OCR_CORRUPTED_STATEMENT = """BANQUE POPULAIRE
 Votre relevé de compte n°4 au 30/04/2026
-DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 76321119905
+DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 12345678901
 
 SOLDE CREDITEUR AU 31/03/2026                                                                                  7 714,94 €
 07/04               ARRETE DE CPTE                                                                     1151121                07/04                    31/03                                 -6175€
                       1 ER TRIMESTRE 2026
-08/04                PRLV SEPA 0035 SDC CENT                                                           OSPWATY                07/04                   07/04                            73 639.47 €
+08/04                PRLV SEPA 0042 SYNDIC EXEM                                                        OSPWATY                07/04                   07/04                            73 639.47 €
                       Paiement de la facture Telepaiem
                       202603280000000141101T01669
 09/04                ECHEANCE PRET                                                                     9185489                07/04                   06/04                                 - 249,08 €
@@ -238,7 +238,7 @@ SOLDE CREDITEUR AU 31/03/2026                                                   
                       INT,   249,08 COM.         0,00E
 10/04                FRAIS MANDAT PRLV SEPA                                                            0063904                09/04                   09/04                                   - 1,00 €
                      XCIMRO10 2026040900063904000001
-                      CREANCIER            0035 SDC CENTRE
+                      CREANCIER            0042 SYNDIC EXEMPLE
 
                                 S DEBITEURS
 TOTAL DES MOUVEMENTS CREDITEURS                                                                                                                                                0,00 €
@@ -248,11 +248,25 @@ SOLDE CREDITEUR AU 30/04/2026*
 Ce document ne justifie pas la déduction de la TVA ou de la charge en matière d'impôt direct.
 
 DETAIL DE VOS MOUVEMENTS SEPA
-VOTRE COMPTE COURANT N° 76321 119905 RELEVE N° 4 AU 30/04/2026
+VOTRE COMPTE COURANT N° 12345 678901 RELEVE N° 4 AU 30/04/2026
 DATE DETAIL DE VOS PRELEVEMENTS SEPA RECUS DEBIT
-07/04 0035 SDC CENTRE LEO LAGRANGE FR93277Z82FAF4 3 639,47 €
+07/04 0042 SYNDIC EXEMPLE ALPHA FR76123Z45TEST4 3 639,47 €
 202603280000000141101T01669 144-1
-Paiement de la facture Telepaiement du 01/04/2026 LES RAGONDINS 79
+Paiement de la facture Telepaiement du 01/04/2026 RESIDENCE TEST 01
+"""
+
+
+SYNTHETIC_BP_CCSCI_ONLY_CLOSING_BALANCE = """BANQUE POPULAIRE
+Votre relevé de compte n°4 au 30/04/2026
+DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 12345678901
+
+SOLDE CREDITEUR AU 31/03/2026
+07/04               ARRETE DE CPTE                                                                     1151121                07/04                    31/03                                 -6175€
+                      1 ER TRIMESTRE 2026
+TOTAL DES MOUVEMENTS DEBITEURS                                                                                 - 61,75 €
+TOTAL DES MOUVEMENTS CREDITEURS                                                                                                                                                0,00 €
+
+SOLDE CREDITEUR AU 30/04/2026                                                                                  7 653,19 €
 """
 
 
@@ -263,7 +277,7 @@ def test_extract_current_account_with_ocr_corrupted_amounts(monkeypatch):
         lambda _: SYNTHETIC_BP_CCSCI_OCR_CORRUPTED_STATEMENT,
     )
     importer = pdfbanquepopulaire.PDFBanquePopulaire(
-        {**ACCOUNTLIST, "76321119905": "Actif:SCIRagondins:CCSCI"}
+        {**ACCOUNTLIST, "12345678901": "Actif:Tests:CCSCI"}
     )
 
     entries = importer.extract("statement.pdf")
@@ -288,5 +302,29 @@ def test_extract_current_account_with_ocr_corrupted_amounts(monkeypatch):
     ]
     assert transactions[0].payee == "ARRETE DE CPTE"
     assert transactions[0].narration == "1 ER TRIMESTRE 2026"
-    assert transactions[1].payee == "PRLV SEPA 0035 SDC CENT"
+    assert transactions[1].payee == "PRLV SEPA 0042 SYNDIC EXEM"
     assert "202603280000000141101T01669" in transactions[1].narration
+
+
+def test_extract_current_account_with_single_closing_balance(monkeypatch):
+    monkeypatch.setattr(
+        pdfbanquepopulaire,
+        "pdf_to_text",
+        lambda _: SYNTHETIC_BP_CCSCI_ONLY_CLOSING_BALANCE,
+    )
+    importer = pdfbanquepopulaire.PDFBanquePopulaire(
+        {**ACCOUNTLIST, "12345678901": "Actif:Tests:CCSCI"}
+    )
+
+    entries = importer.extract("statement.pdf")
+    balances = [entry for entry in entries if isinstance(entry, data.Balance)]
+    transactions = [
+        entry for entry in entries if isinstance(entry, data.Transaction)
+    ]
+
+    assert len(balances) == 1
+    assert balances[0].date == dt.date(2026, 4, 30)
+    assert balances[0].amount.number == Decimal("7653.19")
+    assert [entry.postings[0].units.number for entry in transactions] == [
+        Decimal("-61.75")
+    ]

--- a/pdfbanquepopulaire/pdfbanquepopulaire_test.py
+++ b/pdfbanquepopulaire/pdfbanquepopulaire_test.py
@@ -221,3 +221,72 @@ def test_extract_current_account_without_totals_block(monkeypatch):
     assert len(transactions) == 2
     assert transactions[0].payee == "PRLV SEPA In Extenso Cen"
     assert transactions[1].payee == "EVI ME MARTIAL FAUCHER C"
+
+
+SYNTHETIC_BP_CCSCI_OCR_CORRUPTED_STATEMENT = """BANQUE POPULAIRE
+Votre relevé de compte n°4 au 30/04/2026
+DETAIL DES OPERATIONS DE VOTRE COMPTE COURANT N° 76321119905
+
+SOLDE CREDITEUR AU 31/03/2026                                                                                  7 714,94 €
+07/04               ARRETE DE CPTE                                                                     1151121                07/04                    31/03                                 -6175€
+                      1 ER TRIMESTRE 2026
+08/04                PRLV SEPA 0035 SDC CENT                                                           OSPWATY                07/04                   07/04                            73 639.47 €
+                      Paiement de la facture Telepaiem
+                      202603280000000141101T01669
+09/04                ECHEANCE PRET                                                                     9185489                07/04                   06/04                                 - 249,08 €
+                      DONT CAP           0,00 ASS.      0,00E
+                      INT,   249,08 COM.         0,00E
+10/04                FRAIS MANDAT PRLV SEPA                                                            0063904                09/04                   09/04                                   - 1,00 €
+                     XCIMRO10 2026040900063904000001
+                      CREANCIER            0035 SDC CENTRE
+
+                                S DEBITEURS
+TOTAL DES MOUVEMENTS CREDITEURS                                                                                                                                                0,00 €
+
+SOLDE CREDITEUR AU 30/04/2026*
+(*) Sous réserve des opérations en cours d'enregistrement et d'une provision suffisante et disponible lors de l'arrêté du solde du compte réalisé en fin de journée.
+Ce document ne justifie pas la déduction de la TVA ou de la charge en matière d'impôt direct.
+
+DETAIL DE VOS MOUVEMENTS SEPA
+VOTRE COMPTE COURANT N° 76321 119905 RELEVE N° 4 AU 30/04/2026
+DATE DETAIL DE VOS PRELEVEMENTS SEPA RECUS DEBIT
+07/04 0035 SDC CENTRE LEO LAGRANGE FR93277Z82FAF4 3 639,47 €
+202603280000000141101T01669 144-1
+Paiement de la facture Telepaiement du 01/04/2026 LES RAGONDINS 79
+"""
+
+
+def test_extract_current_account_with_ocr_corrupted_amounts(monkeypatch):
+    monkeypatch.setattr(
+        pdfbanquepopulaire,
+        "pdf_to_text",
+        lambda _: SYNTHETIC_BP_CCSCI_OCR_CORRUPTED_STATEMENT,
+    )
+    importer = pdfbanquepopulaire.PDFBanquePopulaire(
+        {**ACCOUNTLIST, "76321119905": "Actif:SCIRagondins:CCSCI"}
+    )
+
+    entries = importer.extract("statement.pdf")
+    balances = [entry for entry in entries if isinstance(entry, data.Balance)]
+    transactions = [
+        entry for entry in entries if isinstance(entry, data.Transaction)
+    ]
+
+    assert [entry.amount.number for entry in balances] == [
+        Decimal("7714.94"),
+        Decimal("3763.64"),
+    ]
+    assert [entry.date for entry in balances] == [
+        dt.date(2026, 4, 1),
+        dt.date(2026, 4, 30),
+    ]
+    assert [entry.postings[0].units.number for entry in transactions] == [
+        Decimal("-61.75"),
+        Decimal("-3639.47"),
+        Decimal("-249.08"),
+        Decimal("-1.00"),
+    ]
+    assert transactions[0].payee == "ARRETE DE CPTE"
+    assert transactions[0].narration == "1 ER TRIMESTRE 2026"
+    assert transactions[1].payee == "PRLV SEPA 0035 SDC CENT"
+    assert "202603280000000141101T01669" in transactions[1].narration


### PR DESCRIPTION
## Résumé
- rend `pdfbanquepopulaire` robuste à certaines extractions OCR dégradées sur les relevés SCI Banque Populaire
- accepte les montants sans séparateur décimal explicite
- récupère le montant fiable depuis le détail SEPA quand la ligne principale est corrompue
- dérive le solde de clôture quand la ligne de balance finale est tronquée
- ajoute un test de non-régression synthétique/anonymisé
- documente ce comportement dans le README

## Validation
- `./.venv/bin/pytest myTools/pdfbanquepopulaire/pdfbanquepopulaire_test.py -q`
