### PR TITLE
fix: parse Boursorama OPCVM redemption credit notices

### DIFF
--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -68,9 +68,9 @@ class PDFBourso(beangulp.Importer):
 
     REGEX_ACTION_MONTANT = r"Montant brut\s*Commission\s*Frais\s\(.\)\s*Montant net au crédit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3}))?\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*"
 
-    REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits d'entrée\s*Frais H.T.\s*T.V.A.\s*Montant net au débit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
-    REGEX_OPCVM_DETAILS = r"(\d{1,2}\/\d{2}\/\d{4})\s*(\d{0,3}\s\d{1,3}[.,]?\d{0,4})\s*([\s\S]{0,20})?\s*"
-    REGEX_OPCVM_COURS = r"Valeur liquidative :\s*(\d{0,3}\s\d{1,3}[,.]\d{0,4})\s([A-Z]{1,3})"
+    REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits (?:d'entrée|de sortie)\s*Frais H.T.\s*T.V.A.\s*Montant net au (?:débit|crédit) de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*)?(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
+    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
+    REGEX_OPCVM_COURS = r"Valeur liquidative\s*:\s*(\d+(?:\s\d{3})*[,.]\d{1,4})\s([A-Z]{1,3})"
     REGEX_OPCVM_SOUSCRIPTION = r"SOUSCRIPTION"
 
     REGEX_DIVIDENDE_DETAILS = r"(\d{2}\/\d{2}\/\d{4})\s*(\d{1,5})\s*(.*)\s\(([A-Z]{2}[A-Z,0-9]{10})\)\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})?\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})"
@@ -639,12 +639,14 @@ class PDFBourso(beangulp.Importer):
 
         match = re.search(self.REGEX_OPCVM_MONTANT, text)
         if match:
-            ope["Montant Total"] = match.group(7)
-            ope["currency Total"] = match.group(8)
+            ope["Montant Total"] = match.group(9)
+            ope["currency Total"] = match.group(10)
             ope["Frais"] = match.group(5)
             ope["currency Frais"] = match.group(6)
             ope["Droits"] = match.group(3)
             ope["currency Droits"] = match.group(4)
+            ope["TVA"] = match.group(7) or "0.0"
+            ope["currency TVA"] = match.group(8) or ope["currency Frais"]
         else:
             self.logger.info("Montant introuvable")
         self._debug(f"Montant Total : {ope['Montant Total']}")
@@ -702,7 +704,7 @@ class PDFBourso(beangulp.Importer):
             ),
             self._create_posting(
                 "Depenses:Banque:Frais",
-                self._parse_decimal(ope["Frais"]) + self._parse_decimal(ope["Droits"]),
+                self._parse_decimal(ope["Frais"]) + self._parse_decimal(ope["Droits"]) + self._parse_decimal(ope["TVA"]),
                 ope["currency Frais"],
             ),
         ]

--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -69,7 +69,7 @@ class PDFBourso(beangulp.Importer):
     REGEX_ACTION_MONTANT = r"Montant brut\s*Commission\s*Frais\s\(.\)\s*Montant net au crédit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3}))?\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*"
 
     REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits (?:d'entrée|de sortie)\s*Frais H.T.\s*T.V.A.\s*Montant net au (?:débit|crédit) de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*)?(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
-    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
+    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:\s\d{3})*(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
     REGEX_OPCVM_COURS = r"Valeur liquidative\s*:\s*(\d+(?:\s\d{3})*[,.]\d{1,4})\s([A-Z]{1,3})"
     REGEX_OPCVM_SOUSCRIPTION = r"SOUSCRIPTION"
 

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -229,3 +229,31 @@ Montant brut                   Droits de sortie                    Frais H.T.   
     transaction = entries[0]
     assert transaction.date.isoformat() == "2025-07-08"
     assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+
+
+def test_extract_opcvm_reprise_credit_quantity_with_thousands_separator(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             1 234,5678          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+127 987,53 EUR                     0,00 EUR                        0,00 EUR                                                       127 987,53 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+    assert position_posting.units.number == Decimal("-1234.5678")
+    assert cash_posting.units.number == Decimal("127987.53")

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -257,3 +257,34 @@ Montant brut                   Droits de sortie                    Frais H.T.   
     assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
     assert position_posting.units.number == Decimal("-1234.5678")
     assert cash_posting.units.number == Decimal("127987.53")
+
+
+
+def test_extract_opcvm_reprise_credit_with_tva_present(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       99,8600 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 001,00 EUR                       2,00 EUR                        0,00 EUR                      0,40 EUR               998,60 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+    fees_posting = transaction.postings[2]
+
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+    assert position_posting.units.number == Decimal("-10.0000")
+    assert cash_posting.units.number == Decimal("998.60")
+    assert fees_posting.units.number == Decimal("2.40")

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -155,3 +155,77 @@ Date           N° de RIB                                        N° Carte      
     assert fee_entry.postings[0].units.number == Decimal("-0.32")
     assert fee_entry.postings[1].account == "Depenses:Banque:Frais"
     assert fee_entry.postings[1].units.number == Decimal("0.32")
+
+
+def test_extract_opcvm_reprise_credit_layout(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 036,70 EUR                       0,00 EUR                        0,00 EUR                                                       1 036,70 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    assert transaction.date.isoformat() == "2025-07-08"
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+    fees_posting = transaction.postings[2]
+
+    assert position_posting.account == "Actif:Boursorama:PEA:FR0000447039"
+    assert position_posting.units.number == Decimal("-10.0000")
+    assert position_posting.price.number == Decimal("103.6699")
+    assert cash_posting.account == "Actif:Boursorama:PEA:Cash"
+    assert cash_posting.units.number == Decimal("1036.70")
+    assert fees_posting.account == "Depenses:Banque:Frais"
+    assert fees_posting.units.number == Decimal("0.00")
+
+
+def test_extract_opcvm_reprise_credit_real_layout_noise(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+
+
+
+
+                                                                                                                                                                                                            F1
+    08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+
+
+
+
+                                                                                                                                                                                                            P82920 1/1
+                                            Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+
+
+
+
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 036,70 EUR                       0,00 EUR                        0,00 EUR                                                       1 036,70 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    assert transaction.date.isoformat() == "2025-07-08"
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"


### PR DESCRIPTION
## Bug Description

Le parseur `pdfbourso` ne savait pas extraire certains avis Boursorama OPCVM de type reprise/rachat (`REPRISE F.C.P.`), en particulier quand le document utilise la variante `Montant net au crédit` et contient du bruit de mise en page OCR/PDF.

Fixes #

## Root Cause

- regex montant trop spécifique (`Montant net au débit` attendu, mais document réel en `Montant net au crédit`)
- libellés de frais trop rigides (`Droits d'entrée` seulement, alors que le document réel utilise `Droits de sortie`)
- extraction des détails OPCVM trop fragile face au bruit de layout et aux sauts de page
- parsing du cours/VL trop strict sur le format rencontré dans le PDF réel

## Fix

- assouplit les regex OPCVM pour accepter les variantes `crédit`/`débit`
- gère `Droits de sortie` et la TVA absente sans planter
- rend l'extraction des détails plus tolérante au bruit OCR/layout
- ajoute des tests de régression ciblés pour le layout simple et pour un layout réel bruité

## How to Verify

1. `pytest pdfbourso/pdfbourso_test.py -k 'opcvm_reprise_credit_layout or real_layout_noise' -q`
2. `pytest pdfbourso/pdfbourso_test.py -q`
3. Vérifier qu'un PDF réel de type reprise extrait bien une transaction avec quantité négative et cash positif

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

## Risk Assessment

Low — changement ciblé au parseur OPCVM Boursorama, avec couverture de régression sur le format cassé et validation sur la suite de tests dédiée.
