### PR TITLE
fix: improve Boursorama importer for OPCVM and PEA cash statements

### DIFF
--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -68,9 +68,9 @@ class PDFBourso(beangulp.Importer):
 
     REGEX_ACTION_MONTANT = r"Montant brut\s*Commission\s*Frais\s\(.\)\s*Montant net au crédit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3}))?\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*"
 
-    REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits d'entrée\s*Frais H.T.\s*T.V.A.\s*Montant net au débit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
-    REGEX_OPCVM_DETAILS = r"(\d{1,2}\/\d{2}\/\d{4})\s*(\d{0,3}\s\d{1,3}[.,]?\d{0,4})\s*([\s\S]{0,20})?\s*"
-    REGEX_OPCVM_COURS = r"Valeur liquidative :\s*(\d{0,3}\s\d{1,3}[,.]\d{0,4})\s([A-Z]{1,3})"
+    REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits (?:d'entrée|de sortie)\s*Frais H.T.\s*T.V.A.\s*Montant net au (?:débit|crédit) de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*)?(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
+    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
+    REGEX_OPCVM_COURS = r"Valeur liquidative\s*:\s*(\d+(?:\s\d{3})*[,.]\d{1,4})\s([A-Z]{1,3})"
     REGEX_OPCVM_SOUSCRIPTION = r"SOUSCRIPTION"
 
     REGEX_DIVIDENDE_DETAILS = r"(\d{2}\/\d{2}\/\d{4})\s*(\d{1,5})\s*(.*)\s\(([A-Z]{2}[A-Z,0-9]{10})\)\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})?\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})"
@@ -639,12 +639,14 @@ class PDFBourso(beangulp.Importer):
 
         match = re.search(self.REGEX_OPCVM_MONTANT, text)
         if match:
-            ope["Montant Total"] = match.group(7)
-            ope["currency Total"] = match.group(8)
+            ope["Montant Total"] = match.group(9)
+            ope["currency Total"] = match.group(10)
             ope["Frais"] = match.group(5)
             ope["currency Frais"] = match.group(6)
             ope["Droits"] = match.group(3)
             ope["currency Droits"] = match.group(4)
+            ope["TVA"] = match.group(7) or "0.0"
+            ope["currency TVA"] = match.group(8) or ope["currency Frais"]
         else:
             self.logger.info("Montant introuvable")
         self._debug(f"Montant Total : {ope['Montant Total']}")
@@ -702,7 +704,7 @@ class PDFBourso(beangulp.Importer):
             ),
             self._create_posting(
                 "Depenses:Banque:Frais",
-                self._parse_decimal(ope["Frais"]) + self._parse_decimal(ope["Droits"]),
+                self._parse_decimal(ope["Frais"]) + self._parse_decimal(ope["Droits"]) + self._parse_decimal(ope["TVA"]),
                 ope["currency Frais"],
             ),
         ]

--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -69,7 +69,7 @@ class PDFBourso(beangulp.Importer):
     REGEX_ACTION_MONTANT = r"Montant brut\s*Commission\s*Frais\s\(.\)\s*Montant net au crédit de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3}))?\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*"
 
     REGEX_OPCVM_MONTANT = r"Montant brut\s*Droits (?:d'entrée|de sortie)\s*Frais H.T.\s*T.V.A.\s*Montant net au (?:débit|crédit) de votre compte\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*(?:(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s*)?(\d{0,3}\s*\d{1,3}[,.]\d{1,3})\s([A-Z]{3})\s"
-    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
+    REGEX_OPCVM_DETAILS = r"Date\s*Quantité\s*Informations sur la valeur\s*Informations sur l'exécution[\s\S]*?(\d{1,2}\/\d{2}\/\d{4})\s*(\d+(?:\s\d{3})*(?:[,.]\d{1,4})?)\s*([\s\S]{0,80}?)\s*Référence\s*:"
     REGEX_OPCVM_COURS = r"Valeur liquidative\s*:\s*(\d+(?:\s\d{3})*[,.]\d{1,4})\s([A-Z]{1,3})"
     REGEX_OPCVM_SOUSCRIPTION = r"SOUSCRIPTION"
 

--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -28,6 +28,12 @@ from decimal import InvalidOperation
 class PDFBourso(beangulp.Importer):
     """Un importateur pour les relevés PDF Boursorama."""
 
+    BOURSE_CASH_PARENT_ACCOUNTS = {
+        "Actif:Boursorama:PEA",
+        "Actif:Boursorama:PEAPME",
+        "Actif:Boursorama:CTO",
+    }
+
     # Déplacer les constantes de classe en haut pour une meilleure lisibilité
     DOCUMENT_TYPES = {
         "DividendeBourse": r"COUPONS REMBOURSEMENTS :",
@@ -177,10 +183,17 @@ class PDFBourso(beangulp.Importer):
                     isin = match_isin.group(1)
                     self._debug(f"Compte et ISIN : {self.accountList[compte]}:{isin}")
                     return f"{self.accountList[compte]}:{isin}"
-            elif self.type in ["DividendeBourse", "EspeceDividende"]:
+            elif self.type in ["DividendeBourse", "EspeceBourse", "EspeceDividende"]:
                 return f"{self.accountList[compte]}:Cash"
             else:
                 return self.accountList[compte]
+
+    def _resolve_cash_statement_account(self, compte: str, text: str) -> str:
+        """Return the posting/balance account for cash statement-like documents."""
+        base_account = self.accountList[compte]
+        if base_account in self.BOURSE_CASH_PARENT_ACCOUNTS:
+            return f"{base_account}:Cash"
+        return base_account
 
     def date(self, file):
         """
@@ -743,11 +756,14 @@ class PDFBourso(beangulp.Importer):
         control = self.REGEX_COMPTE_COMPTE
         match = re.search(control, text)
         if match:
-            compte = match.group(0).split(" ")[-1]
+            compte = match.group(1).strip()
 
         # Si debogage, affichage de l'extraction
         self._debug(f"Numéro de compte extrait : {compte}")
         columns = self._find_compte_columns(text)
+        base_account = self.accountList[compte]
+        statement_account = self._resolve_cash_statement_account(compte, text)
+        balances_only_statement = base_account in self.BOURSE_CASH_PARENT_ACCOUNTS
 
         # Affichage du solde initial
         match = re.search(self.REGEX_SOLDE_INITIAL, text)
@@ -772,7 +788,7 @@ class PDFBourso(beangulp.Importer):
                 data.Balance(
                     meta,
                     datebalance,
-                    self.accountList[compte],
+                    statement_account,
                     amount.Amount(balance, "EUR"),
                     None,
                     None,
@@ -784,59 +800,60 @@ class PDFBourso(beangulp.Importer):
         # Si debogage, affichage de l'extraction
         self._debug(f"Chunks extraits : {chunks}")
 
-        index = 0
-        for chunk_match in chunks:
-            index += 1
-            meta = data.new_metadata(file, index)
-            meta["source"] = "pdfbourso"
-            meta["document"] = document
-            ope = dict()
-            chunk = chunk_match.groups()
+        if not balances_only_statement:
+            index = 0
+            for chunk_match in chunks:
+                index += 1
+                meta = data.new_metadata(file, index)
+                meta["source"] = "pdfbourso"
+                meta["document"] = document
+                ope = dict()
+                chunk = chunk_match.groups()
 
-            # Si debogage, affichage de l'extraction
-            self._debug(f"Chunk extrait : {chunk}")
+                # Si debogage, affichage de l'extraction
+                self._debug(f"Chunk extrait : {chunk}")
 
-            ope["date"] = chunk[1]
-            # Si debogage, affichage de l'extraction
-            self._debug(f"Date de l'opération : {ope['date']}")
+                ope["date"] = chunk[1]
+                # Si debogage, affichage de l'extraction
+                self._debug(f"Date de l'opération : {ope['date']}")
 
-            fallback_length = (
-                len(chunk[0])
-                + len(chunk[1])
-                + len(chunk[2])
-                + len(chunk[3])
-            )
-            fallback_sign = 1 if fallback_length > 148 else -1
-            ope["montant"] = self._signed_decimal_from_match(text, chunk_match, 4, columns, fallback_sign)
-            ope["type"] = "Credit" if ope["montant"] > 0 else "Debit"
-            # Si débogage, affichage de l'extraction
-            self._debug(f"Montant de l'opération : {ope['montant']}")
+                fallback_length = (
+                    len(chunk[0])
+                    + len(chunk[1])
+                    + len(chunk[2])
+                    + len(chunk[3])
+                )
+                fallback_sign = 1 if fallback_length > 148 else -1
+                ope["montant"] = self._signed_decimal_from_match(text, chunk_match, 4, columns, fallback_sign)
+                ope["type"] = "Credit" if ope["montant"] > 0 else "Debit"
+                # Si débogage, affichage de l'extraction
+                self._debug(f"Montant de l'opération : {ope['montant']}")
 
-            ope["payee"] = re.sub(r"\s+", " ", chunk[0])
-            # Si debogage, affichage de l'extraction
-            self._debug(f"Payee : {ope['payee']}")
+                ope["payee"] = re.sub(r"\s+", " ", chunk[0])
+                # Si debogage, affichage de l'extraction
+                self._debug(f"Payee : {ope['payee']}")
 
-            ope["narration"] = re.sub(r"\s+", " ", chunk[4] or "")
-            # Si debogage, affichage de l'extraction
-            self._debug(f"Narration : {ope['narration']}")
+                ope["narration"] = re.sub(r"\s+", " ", chunk[4] or "")
+                # Si debogage, affichage de l'extraction
+                self._debug(f"Narration : {ope['narration']}")
 
-            # Creation de la transaction
-            postings = [
-                self._create_posting(
-                    self.accountList[compte],
-                    ope["montant"],
-                    "EUR",
-                ),
-            ]
-            transaction = self._create_transaction(
-                meta,
-                parse_datetime(ope["date"], dayfirst=True).date(),
-                ope["payee"] or "inconnu",
-                ope["narration"],
-                data.EMPTY_SET,
-                postings,
-            )
-            entries.append(transaction)
+                # Creation de la transaction
+                postings = [
+                    self._create_posting(
+                        statement_account,
+                        ope["montant"],
+                        "EUR",
+                    ),
+                ]
+                transaction = self._create_transaction(
+                    meta,
+                    parse_datetime(ope["date"], dayfirst=True).date(),
+                    ope["payee"] or "inconnu",
+                    ope["narration"],
+                    data.EMPTY_SET,
+                    postings,
+                )
+                entries.append(transaction)
 
         # Recherche du solde final
         match = re.search(self.REGEX_SOLDE_FINAL, text)
@@ -865,7 +882,7 @@ class PDFBourso(beangulp.Importer):
                     data.Balance(
                         meta,
                         datebalance,
-                        self.accountList[compte],
+                        statement_account,
                         amount.Amount(balance, "EUR"),
                         None,
                         None,

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -229,3 +229,31 @@ Montant brut                   Droits de sortie                    Frais H.T.   
     transaction = entries[0]
     assert transaction.date.isoformat() == "2025-07-08"
     assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+
+
+def test_extract_opcvm_reprise_credit_quantity_with_thousands_separator(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             1 234,5678          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+127 987,53 EUR                     0,00 EUR                        0,00 EUR                                                       127 987,53 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+    assert position_posting.units.number == Decimal("-1234.5678")
+    assert cash_posting.units.number == Decimal("127987.53")

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -257,3 +257,34 @@ Montant brut                   Droits de sortie                    Frais H.T.   
     assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
     assert position_posting.units.number == Decimal("-1234.5678")
     assert cash_posting.units.number == Decimal("127987.53")
+
+
+
+def test_extract_opcvm_reprise_credit_with_tva_present(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       99,8600 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 001,00 EUR                       2,00 EUR                        0,00 EUR                      0,40 EUR               998,60 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+    fees_posting = transaction.postings[2]
+
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+    assert position_posting.units.number == Decimal("-10.0000")
+    assert cash_posting.units.number == Decimal("998.60")
+    assert fees_posting.units.number == Decimal("2.40")

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -105,6 +105,33 @@ Compte 00040132901
     assert transactions[0].postings[0].units.number == Decimal("-37.97")
 
 
+def test_extract_compte_pea_cash_statement_targets_pea_cash(monkeypatch):
+    text = """BOURSORAMA BANQUE
+Relevé au 02/04/2026
+Compte 00090339677
+          Libellé                                                                                              Valeur              Débit                Crédit
+                                                                                             SOLDE AU : 27/02/2026                                            193,78
+03/03/2026 VIR CTo - PEA                                                                                   03/03/2026                                       2.500,00
+01/04/2026 ACHAT ETRANGER                                                                                  01/04/2026                 993,62
+                                Nouveau solde en EUR :                                                                                                      -767,53
+"""
+    monkeypatch.setattr(pdfbourso, "pdf_to_text", lambda _: text)
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_compte("fake.pdf", text, "2026-03-31 Relevé Compte.pdf")
+
+    balances = [entry for entry in entries if isinstance(entry, data.Balance)]
+    transactions = [entry for entry in entries if isinstance(entry, data.Transaction)]
+
+    assert [entry.account for entry in balances] == [
+        "Actif:Boursorama:PEA:Cash",
+        "Actif:Boursorama:PEA:Cash",
+    ]
+    assert balances[0].amount.number == Decimal("193.78")
+    assert abs(balances[1].amount.number) == Decimal("767.53")
+    assert transactions == []
+
+
 def test_extract_espece_bourse_uses_debit_credit_columns_for_balance_sign(monkeypatch):
     text = """BoursoBank
 RELEVE COMPTE ESPECES: FEVRIER 2025

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -155,3 +155,77 @@ Date           N° de RIB                                        N° Carte      
     assert fee_entry.postings[0].units.number == Decimal("-0.32")
     assert fee_entry.postings[1].account == "Depenses:Banque:Frais"
     assert fee_entry.postings[1].units.number == Decimal("0.32")
+
+
+def test_extract_opcvm_reprise_credit_layout(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 036,70 EUR                       0,00 EUR                        0,00 EUR                                                       1 036,70 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    assert transaction.date.isoformat() == "2025-07-08"
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"
+
+    position_posting = transaction.postings[0]
+    cash_posting = transaction.postings[1]
+    fees_posting = transaction.postings[2]
+
+    assert position_posting.account == "Actif:Boursorama:PEA:FR0000447039"
+    assert position_posting.units.number == Decimal("-10.0000")
+    assert position_posting.price.number == Decimal("103.6699")
+    assert cash_posting.account == "Actif:Boursorama:PEA:Cash"
+    assert cash_posting.units.number == Decimal("1036.70")
+    assert fees_posting.account == "Depenses:Banque:Frais"
+    assert fees_posting.units.number == Decimal("0.00")
+
+
+def test_extract_opcvm_reprise_credit_real_layout_noise(monkeypatch):
+    text = """OPERATION SUR OPC
+(Organisme de Placement Collectif)
+le 09/07/2025
+Références de votre compte titres
+40618 80295 00088339677               Compte PEA
+Résident Français
+REPRISE F.C.P.
+Date                Quantité                           Informations sur la valeur                                        Informations sur l'exécution
+
+
+
+
+                                                                                                                                                                                                            F1
+    08/07/2025             10,0000          AXA PEA REGULARITE C FCP 4DEC                                         Référence :                                                                042144476474
+
+
+
+
+                                                                                                                                                                                                            P82920 1/1
+                                            Code ISIN :    FR0000447039                                           Valeur liquidative :                                                       103,6699 EUR
+
+
+
+
+Montant brut                   Droits de sortie                    Frais H.T.                    T.V.A.               Montant net au crédit de votre compte
+1 036,70 EUR                       0,00 EUR                        0,00 EUR                                                       1 036,70 EUR
+"""
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+
+    entries = importer._extract_opcvm("fake.pdf", text, "2025-07-09 Relevé Operation.pdf")
+
+    assert len(entries) == 1
+    transaction = entries[0]
+    assert transaction.date.isoformat() == "2025-07-08"
+    assert transaction.payee == "AXA PEA REGULARITE C FCP 4DEC"


### PR DESCRIPTION
## Summary
- fix Boursorama OPCVM redemption credit notice parsing
- preserve spaced quantities in redemption notices
- add regression coverage for TVA-present redemption layouts
- route Boursorama PEA/PEAPME/CTO cash statements to `:Cash`
- ensure `Compte à vue P.E.A.` statements produce balances only, not transactions

## Validation
- `./.venv/bin/pytest myTools/pdfbourso/pdfbourso_test.py -q` → `7 passed, 1 skipped`
- `./.venv/bin/pytest scripts/test_workflow_validation.py -q --confcutdir=scripts` → `6 passed`
- `./scripts/check_repo.sh` → OK
- `./.venv/bin/bean-check Famille.beancount` → OK

## Notes
- The `:Cash` statement fix is needed because `Actif:Boursorama:PEA` is not directly opened in the ledger; only the cash sub-account exists.
- PEA cash statements should import monthly balances only. Individual operations are handled by operation notices.
