### PR TITLE
fix(pdfbourso): adapter REGEX_DIVIDENDE_DETAILS au nouveau format de colonnes

### DIFF
--- a/pdfbourso/pdfbourso.py
+++ b/pdfbourso/pdfbourso.py
@@ -73,7 +73,7 @@ class PDFBourso(beangulp.Importer):
     REGEX_OPCVM_COURS = r"Valeur liquidative :\s*(\d{0,3}\s\d{1,3}[,.]\d{0,4})\s([A-Z]{1,3})"
     REGEX_OPCVM_SOUSCRIPTION = r"SOUSCRIPTION"
 
-    REGEX_DIVIDENDE_DETAILS = r"(\d{2}\/\d{2}\/\d{4})\s*(\d{1,5})\s*(.*)\s\(([A-Z]{2}[A-Z,0-9]{10})\)\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})?\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})"
+    REGEX_DIVIDENDE_DETAILS = r"(\d{2}\/\d{2}\/\d{4})\s*(.*?)\s+\(([A-Z]{2}[A-Z,0-9]{10})\)\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{1,5})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})\s*(\d{0,3}\s\d{1,3}[,.]\d{2})?\s*(\d{0,3}\s\d{1,3}[,.]\d{2})"
 
     REGEX_ESPECE_BOURSE_SOLDE = r"(\d*/\d*/\d*).*SOLDE\s*(\d{0,3}\s\d{1,3}[,.]\d{1,3})"
 
@@ -309,6 +309,11 @@ class PDFBourso(beangulp.Importer):
             return []
 
     def _extract_dividende_bourse(self, file, text, document):
+        """Extrait les donnees pour les coupons/remboursements en bourse.
+
+        Le regex V2 capture : date, nom, ISIN, montant unitaire, quantite,
+        montant brut global, commission TTC (optionnelle), net client.
+        """
         try:
             entries = []
             compte = self.account(file)
@@ -317,32 +322,56 @@ class PDFBourso(beangulp.Importer):
             meta = data.new_metadata(file, 0)
             meta["source"] = "pdfbourso"
             meta["document"] = document
-            
+
             for chunk in chunks:
                 try:
+                    gross = self._parse_decimal(chunk[5])
+                    net = self._parse_decimal(chunk[7])
+                    commission = self._parse_decimal(chunk[6] or '0')
+
                     postings = [
-                        self._create_posting("Revenus:Dividendes", self._parse_decimal(chunk[4]) * -1, "EUR"),
-                        self._create_posting("Depenses:Impots:IR", self._parse_decimal(chunk[5] or '0') + self._parse_decimal(chunk[6]), "EUR"),
-                        self._create_posting(compte, self._parse_decimal(chunk[7]), "EUR")
+                        self._create_posting(
+                            "Revenus:Dividendes", -gross, "EUR"
+                        ),
                     ]
-                    
+                    postings.append(
+                        self._create_posting(compte, net, "EUR")
+                    )
+
+                    gap = gross - net
+                    if gap > Decimal('0'):
+                        if commission > 0:
+                            postings.append(
+                                self._create_posting(
+                                    "Depenses:Banque:Frais", commission, "EUR"
+                                )
+                            )
+                            gap -= commission
+                        if gap > Decimal('0'):
+                            postings.append(
+                                self._create_posting(
+                                    "Depenses:Impots:IR", gap, "EUR"
+                                )
+                            )
+
                     transaction = self._create_transaction(
                         meta,
                         parse_datetime(chunk[0], dayfirst=True).date(),
-                        f"Dividende pour {chunk[1]} titres {chunk[2]}",
+                        f"Dividende pour {chunk[4]} titres {chunk[1]}",
                         None,
-                        {chunk[3]},
-                        postings
+                        {chunk[2]},
+                        postings,
                     )
                     entries.append(transaction)
                 except Exception as e:
-                    self._error(f"Erreur lors du traitement d'un dividende : {str(e)}")
-            
+                    self._error(
+                        f"Erreur lors du traitement d'un dividende : {str(e)}"
+                    )
+
             return entries
         except Exception as e:
             self._error(f"Erreur lors de l'extraction des dividendes : {str(e)}")
             return []
-
     def _extract_espece_bourse(self, file, text, document):
         """
         Extrait les données pour les espèces en bourse.

--- a/pdfbourso/pdfbourso_test.py
+++ b/pdfbourso/pdfbourso_test.py
@@ -315,3 +315,74 @@ Montant brut                   Droits de sortie                    Frais H.T.   
     assert position_posting.units.number == Decimal("-10.0000")
     assert cash_posting.units.number == Decimal("998.60")
     assert fees_posting.units.number == Decimal("2.40")
+
+
+def test_extract_dividende_bourse_new_layout(monkeypatch):
+    """V2 layout: date, nom, ISIN, unitaire, qté, brut, commission?, net."""
+    text = ("15/05/2026 AXA PEA REGULARITE C FCP 4DEC (FR0000447039) "
+            "10,50 10 105,00 2,00 103,00")
+    monkeypatch.setattr(pdfbourso, "pdf_to_text", lambda _: text)
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+    monkeypatch.setattr(importer, "account", lambda _: "Actif:Boursorama:PEA:Cash")
+
+    entries = importer._extract_dividende_bourse(
+        "fake.pdf", text, "2026-05-15 Relevé Operation.pdf"
+    )
+
+    assert len(entries) == 1
+    txn = entries[0]
+    assert txn.date.isoformat() == "2026-05-15"
+    assert txn.payee == "Dividende pour 10 titres AXA PEA REGULARITE C FCP 4DEC"
+    assert "FR0000447039" in txn.tags  # ISIN tag
+
+    div, cash, fee = txn.postings
+    assert div.account == "Revenus:Dividendes"
+    assert div.units.number == Decimal("-105.00")  # brut négatif
+    assert cash.account == "Actif:Boursorama:PEA:Cash"
+    assert cash.units.number == Decimal("103.00")  # net reçu
+    assert fee.account == "Depenses:Banque:Frais"
+    assert fee.units.number == Decimal("2.00")  # commission
+
+
+def test_extract_dividende_bourse_new_layout_no_commission(monkeypatch):
+    """Sans commission (groupe optionnel vide → '0')."""
+    text = ("15/05/2026 AXA PEA REGULARITE C FCP 4DEC (FR0000447039) "
+            "10,50 10 105,00   105,00")
+    monkeypatch.setattr(pdfbourso, "pdf_to_text", lambda _: text)
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+    monkeypatch.setattr(importer, "account", lambda _: "Actif:Boursorama:PEA:Cash")
+
+    entries = importer._extract_dividende_bourse(
+        "fake.pdf", text, "2026-05-15 Relevé Operation.pdf"
+    )
+
+    assert len(entries) == 1
+    txn = entries[0]
+    div, cash = txn.postings[:2]
+    assert div.units.number == Decimal("-105.00")
+    assert cash.units.number == Decimal("105.00")
+    # Seulement 2 postings : pas de commission, pas d'IR (brut = net)
+    assert len(txn.postings) == 2
+
+
+def test_extract_dividende_bourse_new_layout_with_ir(monkeypatch):
+    """Avec commission + IR (écart brut-net > commission)."""
+    text = ("15/05/2026 AXA PEA REGULARITE C FCP 4DEC (FR0000447039) "
+            "12,50 8 100,00 1,50 81,00")
+    monkeypatch.setattr(pdfbourso, "pdf_to_text", lambda _: text)
+    importer = pdfbourso.PDFBourso(ACCOUNTLIST, debug=True)
+    monkeypatch.setattr(importer, "account", lambda _: "Actif:Boursorama:PEA:Cash")
+
+    entries = importer._extract_dividende_bourse(
+        "fake.pdf", text, "2026-05-15 Relevé Operation.pdf"
+    )
+
+    assert len(entries) == 1
+    txn = entries[0]
+    div, cash, fee, ir = txn.postings
+    assert div.units.number == Decimal("-100.00")
+    assert cash.units.number == Decimal("81.00")
+    assert fee.account == "Depenses:Banque:Frais"
+    assert fee.units.number == Decimal("1.50")
+    assert ir.account == "Depenses:Impots:IR"
+    assert ir.units.number == Decimal("17.50")  # 100 - 81 - 1.50 = 17.50


### PR DESCRIPTION
## Problème

Le format des relevés **Coupons/Remboursements** Boursorama a changé : la colonne **Quantité** est désormais placée **après le montant unitaire**, et non plus juste après la date.

L'ancien regex `REGEX_DIVIDENDE_DETAILS` ne matche plus, ce qui empêche l'extraction des écritures (ex: doc 5285 — 0 entrée extraite au lieu d'1).

## Solution

- **Nouveau regex** capturant : `date, nom, ISIN, montant unitaire, quantité, brut global, commission TTC?, net client`
- **Refonte de `_extract_dividende_bourse`** avec logique de postings adaptative :
  - `Revenus:Dividendes` ← montant brut (négatif)
  - `Cash` ← net reçu (positif)
  - Écart brut − net → `Depenses:Banque:Frais` (commission) puis `Depenses:Impots:IR` (solde éventuel)

## Tests

- 4/4 tests pdfbourso existants passent ✓
- 66/66 tests workflow Beancount-Perso passent ✓
- Import du doc 5285 vérifié : 1 transaction correctement extraite